### PR TITLE
added Add Group button to Groups page

### DIFF
--- a/client/src/components/groups/Groups.test.tsx
+++ b/client/src/components/groups/Groups.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, unmountComponentAtNode } from "react-dom";
+import { act } from "react-dom/test-utils";
+import Groups from "./Groups";
+import { IGroupDto } from "../../generated/backend";
+
+const mockGroup: IGroupDto = {
+  name: "fake group",
+  createdDate: new Date(),
+  updatedDate: new Date(),
+  id: 10,
+  isActive: true,
+};
+
+jest.mock(
+  "./addGroupForm/AddGroupForm",
+  () =>
+    function ({ onSuccess }: any) {
+      return (
+        <form onSubmit={() => onSuccess(mockGroup)}>
+          <button type="submit"></button>
+        </form>
+      );
+    }
+);
+describe("Groups", () => {
+  let container: Element;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+  });
+
+  it("renders a button to add a group", () => {
+    act(() => {
+      render(<Groups />, container);
+    });
+
+    expect(container.querySelector("button").textContent).toBe("Add Group");
+  });
+
+  it("renders a form when clicking the Add Group button", () => {
+    act(() => {
+      render(<Groups />, container);
+      openForm(container);
+    });
+
+    expect(document.body.querySelector("form")).toBeTruthy();
+  });
+
+  it("does not render the Add Group form by default", () => {
+    act(() => {
+      render(<Groups />, container);
+    });
+
+    expect(document.body.querySelector("form")).toBeFalsy();
+  });
+
+  it("adds the new group to the page when onSuccess is called", () => {
+    act(() => {
+      render(<Groups />, container);
+      openForm(container);
+    });
+    act(() => {
+      document.body.querySelector("form").dispatchEvent(new Event("submit"));
+    });
+
+    expect(
+      container.querySelector("div[data-automation-key=id]").textContent
+    ).toBe(mockGroup.id.toString());
+    expect(
+      container.querySelector("div[data-automation-key=name]").textContent
+    ).toBe(mockGroup.name);
+  });
+});
+
+function openForm(container: Element) {
+  container
+    .querySelector("button")
+    .dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}

--- a/client/src/components/groups/Groups.tsx
+++ b/client/src/components/groups/Groups.tsx
@@ -1,37 +1,40 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState } from "react";
 import {
   List,
   IColumn,
   Spinner,
   DetailsList,
   DetailsListLayoutMode,
-  SpinnerSize
-} from '@fluentui/react';
-import { IGroupDto, ApiClient } from '../../generated/backend';
+  SpinnerSize,
+  Modal,
+  mergeStyleSets,
+} from "@fluentui/react";
+import { IGroupDto, ApiClient } from "../../generated/backend";
+import AddGroupForm from "./addGroupForm/AddGroupForm";
 
 const Groups: React.FC = () => {
   const [data, setData] = useState({
     groups: [] as IGroupDto[],
-    isFetching: false
+    isFetching: false,
   });
   const groupKeys: IGroupDto = {
     id: null,
-    name: '',
+    name: "",
     isActive: false,
     createdDate: null,
-    updatedDate: null
+    updatedDate: null,
   };
   const columns = Object.keys(groupKeys).map(
     (key): IColumn => {
       return {
         key,
-        name: key.replace(/([A-Z])/g, ' $1').replace(/^./, (str: string) => {
+        name: key.replace(/([A-Z])/g, " $1").replace(/^./, (str: string) => {
           return str.toUpperCase();
         }),
         fieldName: key,
         minWidth: 100,
         maxWidth: 200,
-        isResizable: true
+        isResizable: true,
       };
     }
   );
@@ -52,16 +55,39 @@ const Groups: React.FC = () => {
     fetchData();
   }, []);
 
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const showModal = () => {
+    setIsModalOpen(true);
+  };
+  const hideModal = () => setIsModalOpen(false);
+
+  const onSuccess = (group: IGroupDto) => {
+    setData({
+      groups: [...data.groups, group],
+      isFetching: false,
+    });
+    hideModal();
+  };
+
   return (
     <>
       <h2>Groups</h2>
+      <button onClick={showModal}>Add Group</button>
+      <Modal
+        isOpen={isModalOpen}
+        onDismiss={hideModal}
+        containerClassName={contentStyles.container}
+      >
+        <AddGroupForm onSuccess={onSuccess} />
+      </Modal>
       <DetailsList
-        items={data.groups.map(group => {
+        items={data.groups.map((group) => {
           return {
             ...group,
             createdDate: group.createdDate.toLocaleString(),
             updatedDate: group.updatedDate.toLocaleString(),
-            isActive: group.isActive.toString()
+            isActive: group.isActive.toString(),
           };
         })}
         columns={columns}
@@ -71,5 +97,17 @@ const Groups: React.FC = () => {
     </>
   );
 };
+
+const contentStyles = mergeStyleSets({
+  container: {
+    display: "flex",
+    flexFlow: "column nowrap",
+    alignItems: "stretch",
+    paddingLeft: "24px",
+    paddingRight: "24px",
+    paddingBottom: "12px",
+    minWidth: "330px",
+  },
+});
 
 export default Groups;

--- a/client/src/components/groups/addGroupForm/AddGroupForm.test.tsx
+++ b/client/src/components/groups/addGroupForm/AddGroupForm.test.tsx
@@ -1,0 +1,119 @@
+import React from "react";
+import { render, unmountComponentAtNode } from "react-dom";
+import { IGroupDto } from "../../../generated/backend";
+import { act } from "react-dom/test-utils";
+
+import AddGroupForm from "./AddGroupForm";
+import * as fluentui from "@fluentui/react";
+
+describe("AddGroupForm", () => {
+  let mockUser: IGroupDto;
+  let container: HTMLDivElement = null;
+  let onSuccess: jest.Mock<void, any>;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    mockUser = {
+      name: "Joni Baez",
+      isActive: true,
+      createdDate: new Date(),
+      updatedDate: new Date(),
+      id: 10,
+    };
+
+    onSuccess = jest.fn((_response: IGroupDto) => {});
+
+    jest.spyOn(global, "fetch" as any).mockImplementation(() =>
+      Promise.resolve({
+        text: () => Promise.resolve(JSON.stringify(mockUser)),
+        status: 201,
+      })
+    );
+  });
+
+  afterEach(() => {
+    unmountComponentAtNode(container);
+    container.remove();
+    container = null;
+    (global as any).fetch.mockRestore();
+  });
+
+  it("renders an text input for the name", () => {
+    act(() => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+    });
+    const input = container.querySelector("input[type=text]");
+    expect(input).toBeTruthy();
+    const id = input.id;
+    expect(container.querySelector(`label[for=${id}`).textContent).toBe("Name");
+  });
+
+  it("requires a name to be entered", () => {
+    act(() => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+    });
+
+    expect(
+      container.querySelector("input[type=text]").hasAttribute("required")
+    ).toBeTruthy();
+  });
+
+  it("renders a checkbox for Is Active", () => {
+    act(() => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+    });
+
+    const checkbox = container.querySelector("input[type=checkbox]");
+    expect(checkbox).toBeTruthy();
+    expect(
+      container.querySelector(`label[for=${checkbox.id}]`).textContent
+    ).toBe("Is Active");
+  });
+
+  it("calls the onSuccess handler with the response", async () => {
+    await act(async () => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+      submitForm(container, mockUser.name);
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith(mockUser);
+  });
+
+  it("displays an error message when the api request fails", async () => {
+    await act(async () => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+      jest
+        .spyOn(global, "fetch" as any)
+        .mockImplementation(() => Promise.reject("the request failed"));
+
+      submitForm(container, mockUser.name);
+    });
+
+    expect(container.querySelector(".ms-MessageBar").textContent).toBe(
+      "There was an error adding your group."
+    );
+  });
+
+  it("displays a spinner when the form is submitted", async () => {
+    const mockSpinner = jest.fn(() => <div></div>);
+
+    (fluentui as any).Spinner = mockSpinner;
+    await act(async () => {
+      render(<AddGroupForm onSuccess={onSuccess} />, container);
+      submitForm(container, mockUser.name);
+    });
+
+    expect(mockSpinner).toHaveBeenCalled();
+    mockSpinner.mockRestore();
+  });
+});
+
+function submitForm(container: Element, textInput: string) {
+  const nameInput = container.querySelector("input[type=text]");
+  nameInput.nodeValue = textInput;
+
+  const button = container.querySelector("button");
+  button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}

--- a/client/src/components/groups/addGroupForm/AddGroupForm.tsx
+++ b/client/src/components/groups/addGroupForm/AddGroupForm.tsx
@@ -1,0 +1,91 @@
+import {
+  Checkbox,
+  mergeStyleSets,
+  MessageBar,
+  MessageBarType,
+  Spinner,
+  SpinnerSize,
+  TextField,
+} from "@fluentui/react";
+import React, { useState } from "react";
+import { GroupDto, ApiClient, IGroupDto } from "../../../generated/backend";
+
+export interface IAddGroupFormProps {
+  onSuccess(group: IGroupDto): void;
+}
+
+const AddGroupForm: React.FC<IAddGroupFormProps> = ({ onSuccess }) => {
+  const [name, setName] = useState("");
+  const setNameField = React.useCallback(
+    (
+      _event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+      newValue?: string
+    ) => {
+      setName(newValue || "");
+    },
+    []
+  );
+
+  const [isActive, setIsActive] = useState(true);
+  const onIsActiveChange = React.useCallback(
+    (_ev: React.FormEvent<HTMLElement>, checked: boolean) =>
+      setIsActive(!!checked),
+    []
+  );
+
+  const [error, setError] = useState(null);
+  const hideError = () => setError(null);
+
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const group = GroupDto.fromJS({ name, isActive });
+    setIsLoading(true);
+    await new ApiClient(process.env.REACT_APP_API_BASE)
+      .groups_CreateGroup(group)
+      .then(onSuccess)
+      .catch((error) => {
+        console.error(error);
+        setError(error);
+      })
+      .then(() => setIsLoading(false));
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <h4>Add a Group</h4>
+      {error && (
+        <MessageBar
+          messageBarType={MessageBarType.error}
+          isMultiline={false}
+          dismissButtonAriaLabel="Close"
+          onDismiss={hideError}
+        >
+          There was an error adding your group.
+        </MessageBar>
+      )}
+      <TextField label="Name" required value={name} onChange={setNameField} />
+      <Checkbox
+        label="Is Active"
+        checked={isActive}
+        onChange={onIsActiveChange}
+        className={contentStyles.checkBox}
+      />
+      <button className={contentStyles.submitButton} type="submit">
+        {isLoading ? <Spinner size={SpinnerSize.medium} /> : "Submit"}
+      </button>
+    </form>
+  );
+};
+
+const contentStyles = mergeStyleSets({
+  submitButton: {
+    width: "60px",
+  },
+  checkBox: {
+    padding: "12px 0px 12px 0px",
+  },
+});
+
+export default AddGroupForm;

--- a/service/Microsoft.DSX.ProjectTemplate.API/Controllers/GroupsController.cs
+++ b/service/Microsoft.DSX.ProjectTemplate.API/Controllers/GroupsController.cs
@@ -44,7 +44,8 @@ namespace Microsoft.DSX.ProjectTemplate.API.Controllers
         [HttpPost]
         public async Task<ActionResult<GroupDto>> CreateGroup([FromBody] GroupDto dto)
         {
-            return Ok(await Mediator.Send(new CreateGroupCommand() { Group = dto }));
+            var group = await Mediator.Send(new CreateGroupCommand() { Group = dto });
+            return CreatedAtAction("GetGroup", new { id = group.Id }, group);
         }
 
         /// <summary>

--- a/service/Microsoft.DSX.ProjectTemplate.Test/Tests/Integration/Group/CreateGroupTests.cs
+++ b/service/Microsoft.DSX.ProjectTemplate.Test/Tests/Integration/Group/CreateGroupTests.cs
@@ -91,7 +91,7 @@ namespace Microsoft.DSX.ProjectTemplate.Test.Tests.Integration.Group
             var response = await Client.PostAsJsonAsync("/api/groups", dto);
 
             // Assert
-            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            response.StatusCode.Should().Be(HttpStatusCode.Created);
 
             GetSentCount().Should().Be(1);
         }


### PR DESCRIPTION
## Task

1. Add a button to the groups page to allow the user to add a new group record to the database
2. When clicked, open a modal form to get data from the user.
3. The name field is required.  Add error handling when the user does not enter a name.
4. Allow the user to save this record to the database.
5. Once “save” is pressed, return the user to the group screen with the new group displayed in the list.

## Notes

- my editor formatted the modified files according to the `.prettierrc` file so there are some extra nonfunctional changes in spread throughout the diff.
- I could not run the latest version of master on my machine by following the instructions in the README. The previous commit worked fine so I chose to revert the latest commit on master and work off that. 